### PR TITLE
Make matching case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add support for plugin config ([#13](https://github.com/jest-community/jest-watch-typeahead/pull/13))
 
 ### Fixes
+* Make matching case insensitive  ([#18](https://github.com/jest-community/jest-watch-typeahead/pull/18))
 * fix: migrate to use jest-watcher ([#6](https://github.com/jest-community/jest-watch-typeahead/pull/6))
 
 

--- a/src/file_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/file_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
@@ -80,6 +80,23 @@ exports[`can use arrows to select a specific file 1`] = `
 [MOCK - cursorRestorePosition]
 `;
 
+exports[`file matching is case insensitive 1`] = `
+
+
+
+ pattern › fI
+[MOCK - cursorSavePosition]
+
+
+ Pattern matches 2 files
+
+ › src/file-1.js
+
+ › src/file-2.js
+[MOCK - cursorTo(13, 5)]
+[MOCK - cursorRestorePosition]
+`;
+
 exports[`shows the correct initial state 1`] = `
 [MOCK - cursorHide]
 [MOCK - clearScreen]

--- a/src/file_name_plugin/__tests__/plugin.test.js
+++ b/src/file_name_plugin/__tests__/plugin.test.js
@@ -91,3 +91,22 @@ it('can configure the key and prompt', async () => {
     prompt: 'have a custom prompt',
   });
 });
+
+it('file matching is case insensitive', async () => {
+  const {
+    stdout,
+    hookEmitter,
+    updateConfigAndRun,
+    plugin,
+    type,
+  } = pluginTester(FileNamePlugin);
+
+  hookEmitter.onFileChange({ projects });
+  const runPromise = plugin.run({}, updateConfigAndRun);
+  type('f');
+  stdout.write.mockReset();
+  type('I');
+  expect(stdout.write.mock.calls.join('\n')).toMatchSnapshot();
+  type(KEYS.ENTER);
+  await runPromise;
+});

--- a/src/file_name_plugin/prompt.js
+++ b/src/file_name_plugin/prompt.js
@@ -88,24 +88,17 @@ export default class FileNamePatternPrompt extends PatternPrompt {
     try {
       regex = new RegExp(pattern, 'i');
     } catch (e) {
-      regex = null;
+      return [];
     }
 
-    let tests = [];
-    if (regex) {
-      this._searchSources.forEach(({ testPaths, config }) => {
-        tests = tests.concat(
-          testPaths
-            .filter(testPath => (regex ? testPath.match(regex) : false))
-            .map(path => ({
-              path,
-              context: { config },
-            })),
-        );
-      });
-    }
-
-    return tests;
+    return this._searchSources.reduce((tests, { testPaths, config }) => {
+      return tests.concat(
+        testPaths.filter(testPath => regex.test(testPath)).map(path => ({
+          path,
+          context: { config },
+        })),
+      );
+    }, []);
   }
 
   updateSearchSources(searchSources: SearchSources) {

--- a/src/file_name_plugin/prompt.js
+++ b/src/file_name_plugin/prompt.js
@@ -95,10 +95,12 @@ export default class FileNamePatternPrompt extends PatternPrompt {
     if (regex) {
       this._searchSources.forEach(({ testPaths, config }) => {
         tests = tests.concat(
-          testPaths.filter(testPath => testPath.match(pattern)).map(path => ({
-            path,
-            context: { config },
-          })),
+          testPaths
+            .filter(testPath => (regex ? testPath.match(regex) : false))
+            .map(path => ({
+              path,
+              context: { config },
+            })),
         );
       });
     }

--- a/src/test_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/test_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
@@ -119,3 +119,20 @@ Pattern Mode Usage
 [MOCK - cursorTo(11, 5)]
 [MOCK - cursorRestorePosition]
 `;
+
+exports[`test matching is case insensitive 1`] = `
+
+
+
+ pattern › fO
+[MOCK - cursorSavePosition]
+
+
+ Pattern matches 2 tests from cached test suites
+
+ › foo 1
+
+ › foo 2
+[MOCK - cursorTo(13, 5)]
+[MOCK - cursorRestorePosition]
+`;

--- a/src/test_name_plugin/__tests__/plugin.test.js
+++ b/src/test_name_plugin/__tests__/plugin.test.js
@@ -92,3 +92,22 @@ it('can configure the key and prompt', async () => {
     prompt: 'have a custom prompt',
   });
 });
+
+it('test matching is case insensitive', async () => {
+  const {
+    stdout,
+    hookEmitter,
+    updateConfigAndRun,
+    plugin,
+    type,
+  } = pluginTester(TestNamePlugin);
+
+  hookEmitter.onTestRunComplete({ testResults });
+  const runPromise = plugin.run({}, updateConfigAndRun);
+  type('f');
+  stdout.write.mockReset();
+  type('O');
+  expect(stdout.write.mock.calls.join('\n')).toMatchSnapshot();
+  type(KEYS.ENTER);
+  await runPromise;
+});

--- a/src/test_name_plugin/prompt.js
+++ b/src/test_name_plugin/prompt.js
@@ -83,17 +83,13 @@ class TestNamePatternPrompt extends PatternPrompt {
       return [];
     }
 
-    const matchedTests = [];
-
-    this._cachedTestResults.forEach(({ testResults }) =>
-      testResults.forEach(({ title }) => {
-        if (regex.test(title)) {
-          matchedTests.push(title);
-        }
-      }),
-    );
-
-    return matchedTests;
+    return this._cachedTestResults.reduce((matchedTests, { testResults }) => {
+      return matchedTests.concat(
+        testResults
+          .filter(({ title }) => regex.test(title))
+          .map(({ title }) => title),
+      );
+    }, []);
   }
 
   updateCachedTestResults(testResults: Array<TestResult> = []) {


### PR DESCRIPTION
Fixes: #10 

`testNamePattern` is case insensitive, so the typeahead should respect that.

This was a regression introduced when I extracted the typeahead from Jest core.