### PR TITLE
Fix cursor in terminal app

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format": "prettier --single-quote --trailing-comma all --write \"!(build)/**/*.js\""
   },
   "dependencies": {
+    "ansi-escapes": "^3.1.0",
     "chalk": "^2.4.1",
     "jest-watcher": "^23.1.0",
     "slash": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "prettier --single-quote --trailing-comma all --write \"!(build)/**/*.js\""
   },
   "dependencies": {
-    "ansi-escapes": "^3.1.0",
+    "ansi-escapes": "^3.0.0",
     "chalk": "^2.4.1",
     "jest-watcher": "^23.1.0",
     "slash": "^1.0.0",

--- a/src/file_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/file_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
@@ -2,10 +2,11 @@
 
 exports[`can select a pattern that matches multiple files 1`] = `
 
-
+[MOCK - cursorLeft]
 
  pattern › f
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 3 files
@@ -18,10 +19,11 @@ exports[`can select a pattern that matches multiple files 1`] = `
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
-
+[MOCK - cursorLeft]
 
  pattern › fi
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 files
@@ -35,10 +37,11 @@ exports[`can select a pattern that matches multiple files 1`] = `
 
 exports[`can use arrows to select a specific file 1`] = `
 
-
+[MOCK - cursorLeft]
 
  pattern › f
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 3 files
@@ -51,10 +54,11 @@ exports[`can use arrows to select a specific file 1`] = `
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
-
+[MOCK - cursorLeft]
 
  pattern › fi
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 files
@@ -65,10 +69,11 @@ exports[`can use arrows to select a specific file 1`] = `
 [MOCK - cursorTo(13, 5)]
 [MOCK - cursorRestorePosition]
 
-
+[MOCK - cursorLeft]
 
  pattern › fi
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 files
@@ -82,10 +87,11 @@ exports[`can use arrows to select a specific file 1`] = `
 
 exports[`file matching is case insensitive 1`] = `
 
-
+[MOCK - cursorLeft]
 
  pattern › fI
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 files
@@ -108,10 +114,11 @@ Pattern Mode Usage
 
 [MOCK - cursorShow]
 
-
+[MOCK - cursorLeft]
 
  pattern › 
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Start typing to filter by a filename regex pattern.

--- a/src/file_name_plugin/prompt.js
+++ b/src/file_name_plugin/prompt.js
@@ -1,6 +1,7 @@
 // @flow
 
 import chalk from 'chalk';
+import ansiEscapes from 'ansi-escapes';
 import stringLength from 'string-length';
 import {
   Prompt,
@@ -45,6 +46,8 @@ export default class FileNamePatternPrompt extends PatternPrompt {
     const prompt = this._prompt;
 
     printPatternCaret(pattern, pipe);
+
+    pipe.write(ansiEscapes.cursorLeft);
 
     if (pattern) {
       printPatternMatches(total, 'file', pipe);

--- a/src/test_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/test_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
@@ -2,10 +2,11 @@
 
 exports[`can select a pattern that matches multiple tests 1`] = `
 
-
+[MOCK - cursorLeft]
 
  pattern › f
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 tests from cached test suites
@@ -16,10 +17,11 @@ exports[`can select a pattern that matches multiple tests 1`] = `
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
-
+[MOCK - cursorLeft]
 
  pattern › fo
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 tests from cached test suites
@@ -33,10 +35,11 @@ exports[`can select a pattern that matches multiple tests 1`] = `
 
 exports[`can use arrows to select a specific test 1`] = `
 
-
+[MOCK - cursorLeft]
 
  pattern › f
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 tests from cached test suites
@@ -47,10 +50,11 @@ exports[`can use arrows to select a specific test 1`] = `
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
-
+[MOCK - cursorLeft]
 
  pattern › f
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 tests from cached test suites
@@ -61,10 +65,11 @@ exports[`can use arrows to select a specific test 1`] = `
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
-
+[MOCK - cursorLeft]
 
  pattern › f
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 tests from cached test suites
@@ -87,10 +92,11 @@ Pattern Mode Usage
 
 [MOCK - cursorShow]
 
-
+[MOCK - cursorLeft]
 
  pattern › 
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Start typing to filter by a test name regex pattern.
@@ -109,10 +115,11 @@ Pattern Mode Usage
 
 [MOCK - cursorShow]
 
-
+[MOCK - cursorLeft]
 
  pattern › 
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Start typing to filter by a test name regex pattern.
@@ -122,10 +129,11 @@ Pattern Mode Usage
 
 exports[`test matching is case insensitive 1`] = `
 
-
+[MOCK - cursorLeft]
 
  pattern › fO
 [MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
 
 
  Pattern matches 2 tests from cached test suites

--- a/src/test_name_plugin/prompt.js
+++ b/src/test_name_plugin/prompt.js
@@ -1,6 +1,7 @@
 // @flow
 
 import chalk from 'chalk';
+import ansiEscapes from 'ansi-escapes';
 import {
   Prompt,
   PatternPrompt,
@@ -44,6 +45,8 @@ class TestNamePatternPrompt extends PatternPrompt {
     const prompt = this._prompt;
 
     printPatternCaret(pattern, pipe);
+
+    pipe.write(ansiEscapes.cursorLeft);
 
     if (pattern) {
       printPatternMatches(

--- a/src/test_utils/pluginTester.js
+++ b/src/test_utils/pluginTester.js
@@ -9,6 +9,7 @@ expect.addSnapshotSerializer({
 jest.mock('ansi-escapes', () => ({
   clearScreen: '[MOCK - clearScreen]',
   cursorDown: (count = 1) => `[MOCK - cursorDown(${count})]`,
+  cursorLeft: '[MOCK - cursorLeft]',
   cursorHide: '[MOCK - cursorHide]',
   cursorRestorePosition: '[MOCK - cursorRestorePosition]',
   cursorSavePosition: '[MOCK - cursorSavePosition]',

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,6 +143,10 @@ ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
+ansi-escapes@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,10 +143,6 @@ ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
-ansi-escapes@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
Fixes: #20 

This PR fixes an issue with terminals like Terminal.app in MacOS... We've seen similar issues in the past, when the typeahead was inside Jest core _(i.e. https://github.com/facebook/jest/pull/3392 and https://github.com/facebook/jest/pull/2594)_ but I still want to further investigate the issue.

By reseting the cursor to the position `x=0` of the current line(the leftmost position) we ensure the text starts in the correct position. Although this fixes it, I still want to have a better understanding of why this regression happened and how to prevent similar issues in the future.

<img width="569" alt="screen shot 2018-10-04 at 10 50 30 pm" src="https://user-images.githubusercontent.com/574806/46518220-f422c800-c827-11e8-9599-deda6894b864.png">


This gif shows be behavior in master vs this PR
![jest-watch-bug](https://user-images.githubusercontent.com/574806/46518083-66df7380-c827-11e8-8b71-bc2748aa688e.gif)
