### PR TITLE
Use fullName(to show ancestor titles) for test name pattern plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## master
 
+### Chore & Maintenance
+
+- Bump dated dependencies ([#25](https://github.com/jest-community/jest-watch-typeahead/pull/25))
+
+### Fixes
+
+- Use fullName(to show ancestor titles) for test name pattern plugin ([#26](https://github.com/jest-community/jest-watch-typeahead/pull/26))
+
 ## 0.2.1
 
 - Fix cursor in terminal app ([#21](https://github.com/jest-community/jest-watch-typeahead/pull/21))

--- a/src/test_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/test_name_plugin/__tests__/__snapshots__/plugin.test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`can select a pattern that matches a describe block 1`] = `
+
+[MOCK - cursorLeft]
+
+ pattern › s
+[MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
+
+
+ Pattern matches 4 tests from cached test suites
+
+ › some description foo 1
+
+ › some description bar 1
+
+ › other description foo 2
+
+ › other description bar 2
+[MOCK - cursorTo(12, 5)]
+[MOCK - cursorRestorePosition]
+
+[MOCK - cursorLeft]
+
+ pattern › so
+[MOCK - cursorSavePosition]
+[MOCK - cursorLeft]
+
+
+ Pattern matches 2 tests from cached test suites
+
+ › some description foo 1
+
+ › some description bar 1
+[MOCK - cursorTo(13, 5)]
+[MOCK - cursorRestorePosition]
+`;
+
 exports[`can select a pattern that matches multiple tests 1`] = `
 
 [MOCK - cursorLeft]
@@ -11,9 +48,9 @@ exports[`can select a pattern that matches multiple tests 1`] = `
 
  Pattern matches 2 tests from cached test suites
 
- › foo 1
+ › some description foo 1
 
- › foo 2
+ › other description foo 2
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
@@ -26,9 +63,9 @@ exports[`can select a pattern that matches multiple tests 1`] = `
 
  Pattern matches 2 tests from cached test suites
 
- › foo 1
+ › some description foo 1
 
- › foo 2
+ › other description foo 2
 [MOCK - cursorTo(13, 5)]
 [MOCK - cursorRestorePosition]
 `;
@@ -44,9 +81,9 @@ exports[`can use arrows to select a specific test 1`] = `
 
  Pattern matches 2 tests from cached test suites
 
- › foo 1
+ › some description foo 1
 
- › foo 2
+ › other description foo 2
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
@@ -59,9 +96,9 @@ exports[`can use arrows to select a specific test 1`] = `
 
  Pattern matches 2 tests from cached test suites
 
- › foo 1
+ › some description foo 1
 
- › foo 2
+ › other description foo 2
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 
@@ -74,9 +111,9 @@ exports[`can use arrows to select a specific test 1`] = `
 
  Pattern matches 2 tests from cached test suites
 
- › foo 1
+ › some description foo 1
 
- › foo 2
+ › other description foo 2
 [MOCK - cursorTo(12, 5)]
 [MOCK - cursorRestorePosition]
 `;
@@ -138,9 +175,9 @@ exports[`test matching is case insensitive 1`] = `
 
  Pattern matches 2 tests from cached test suites
 
- › foo 1
+ › some description foo 1
 
- › foo 2
+ › other description foo 2
 [MOCK - cursorTo(13, 5)]
 [MOCK - cursorRestorePosition]
 `;

--- a/src/test_name_plugin/__tests__/plugin.test.js
+++ b/src/test_name_plugin/__tests__/plugin.test.js
@@ -4,10 +4,16 @@ import TestNamePlugin from '../plugin';
 
 const testResults = [
   {
-    testResults: [{ title: 'foo 1' }, { title: 'bar 1' }],
+    testResults: [
+      { title: 'foo 1', fullName: 'some description foo 1' },
+      { title: 'bar 1', fullName: 'some description bar 1' },
+    ],
   },
   {
-    testResults: [{ title: 'foo 2' }, { title: 'bar 2' }],
+    testResults: [
+      { title: 'foo 2', fullName: 'other description foo 2' },
+      { title: 'bar 2', fullName: 'other description bar 2' },
+    ],
   },
 ];
 
@@ -54,7 +60,7 @@ it('can use arrows to select a specific test', async () => {
 
   expect(updateConfigAndRun).toHaveBeenCalledWith({
     mode: 'watch',
-    testNamePattern: 'foo 2',
+    testNamePattern: 'other description foo 2',
   });
 });
 
@@ -78,6 +84,29 @@ it('can select a pattern that matches multiple tests', async () => {
   expect(updateConfigAndRun).toHaveBeenCalledWith({
     mode: 'watch',
     testNamePattern: 'fo',
+  });
+});
+
+it('can select a pattern that matches a describe block', async () => {
+  const {
+    stdout,
+    hookEmitter,
+    updateConfigAndRun,
+    plugin,
+    type,
+  } = pluginTester(TestNamePlugin);
+
+  hookEmitter.onTestRunComplete({ testResults });
+  const runPromise = plugin.run({}, updateConfigAndRun);
+  stdout.write.mockReset();
+  type('s', 'o', KEYS.ENTER);
+  expect(stdout.write.mock.calls.join('\n')).toMatchSnapshot();
+
+  await runPromise;
+
+  expect(updateConfigAndRun).toHaveBeenCalledWith({
+    mode: 'watch',
+    testNamePattern: 'so',
   });
 });
 

--- a/src/test_name_plugin/prompt.js
+++ b/src/test_name_plugin/prompt.js
@@ -89,8 +89,8 @@ class TestNamePatternPrompt extends PatternPrompt {
     return this._cachedTestResults.reduce((matchedTests, { testResults }) => {
       return matchedTests.concat(
         testResults
-          .filter(({ title }) => regex.test(title))
-          .map(({ title }) => title),
+          .filter(({ fullName }) => regex.test(fullName))
+          .map(({ fullName }) => fullName),
       );
     }, []);
   }


### PR DESCRIPTION
Fixes: #24 

This should allow the test name pattern plugin to display "describe" blocks.

![Screen Shot 2019-03-13 at 4 46 15 PM](https://user-images.githubusercontent.com/574806/54321760-a2892100-45af-11e9-8c3e-01a806f7c7a5.png)


I think we don't need to check for `fullName` and `title` because watch plugins were introduced in Jest@23 and `fullName` [was added in Jest@21](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2100)

* Should we decorate the output to better format each of the nested describe block(by using `ancestorTitles`) instead of a sentence? Or should we keep it as a sentence-ish? @SimenB 	