### PR TITLE
Get better truncation for testname typeahead by truncating the start and not the end

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,13 +12,7 @@
     "strict": 0,
     "no-underscore-dangle": 0,
     "arrow-body-style": 0,
-    "prettier/prettier": [
-      "error",
-      {
-        "singleQuote": true,
-        "trailingComma": "all"
-      }
-    ]
+    "prettier/prettier": 2
   },
   "env": {
     "jest/globals": true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Chore & Maintenance
 
 - Bump dated dependencies ([#25](https://github.com/jest-community/jest-watch-typeahead/pull/25))
+- Get better truncation for testname typeahead by truncating the start and not the end ([#28](https://github.com/jest-community/jest-watch-typeahead/pull/28))
 
 ### Fixes
 

--- a/src/lib/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/lib/__tests__/__snapshots__/utils.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="5" 1`] = `"<dim>th</></>...</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="5" 1`] = `"</>...me</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="10" 1`] = `"<dim>the tes</></>...</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="10" 1`] = `"<dim>...st </></>name</>"`;
 
 exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="15" 1`] = `"<dim>the test </></>name</>"`;
 
@@ -12,9 +12,9 @@ exports[`formatTestNameByPattern formats when testname="the test name", pattern=
 
 exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="30" 1`] = `"<dim>the test </></>name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="5" 1`] = `"<dim>th</></>...</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="5" 1`] = `"</>...</><dim>me</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="10" 1`] = `"<dim>the </></>tes...</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="10" 1`] = `"</>...st</><dim> name</>"`;
 
 exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="15" 1`] = `"<dim>the </></>test</><dim> name</>"`;
 
@@ -24,9 +24,9 @@ exports[`formatTestNameByPattern formats when testname="the test name", pattern=
 
 exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="30" 1`] = `"<dim>the </></>test</><dim> name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="5" 1`] = `"</>th...</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="5" 1`] = `"</>...</><dim>me</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="10" 1`] = `"</>the</><dim> tes...</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="10" 1`] = `"</>...</><dim>st name</>"`;
 
 exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="15" 1`] = `"</>the</><dim> test name</>"`;
 

--- a/src/lib/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/lib/__tests__/__snapshots__/utils.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="5" 1`] = `"<dim>th</></>...</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="10" 1`] = `"<dim>the tes</></>...</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="15" 1`] = `"<dim>the test </></>name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="20" 1`] = `"<dim>the test </></>name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="25" 1`] = `"<dim>the test </></>name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="30" 1`] = `"<dim>the test </></>name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="5" 1`] = `"<dim>th</></>...</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="10" 1`] = `"<dim>the </></>tes...</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="15" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="20" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="25" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="30" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="5" 1`] = `"</>th...</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="10" 1`] = `"</>the</><dim> tes...</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="15" 1`] = `"</>the</><dim> test name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="20" 1`] = `"</>the</><dim> test name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="25" 1`] = `"</>the</><dim> test name</>"`;
+
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="30" 1`] = `"</>the</><dim> test name</>"`;

--- a/src/lib/__tests__/utils.test.js
+++ b/src/lib/__tests__/utils.test.js
@@ -1,5 +1,5 @@
 import stripAnsi from 'strip-ansi';
-import { trimAndFormatPath } from '../utils';
+import { trimAndFormatPath, formatTestNameByPattern } from '../utils';
 
 test('trimAndFormatPath', () => {
   expect(
@@ -7,4 +7,35 @@ test('trimAndFormatPath', () => {
       trimAndFormatPath(2, { cwd: '/hello/there' }, '/hello/there/to/you', 80),
     ),
   ).toEqual('to/you');
+});
+
+describe('formatTestNameByPattern', () => {
+  test.each`
+    testName           | pattern   | width
+    ${'the test name'} | ${'the'}  | ${30}
+    ${'the test name'} | ${'the'}  | ${25}
+    ${'the test name'} | ${'the'}  | ${20}
+    ${'the test name'} | ${'the'}  | ${15}
+    ${'the test name'} | ${'the'}  | ${10}
+    ${'the test name'} | ${'the'}  | ${5}
+    ${'the test name'} | ${'test'} | ${30}
+    ${'the test name'} | ${'test'} | ${25}
+    ${'the test name'} | ${'test'} | ${20}
+    ${'the test name'} | ${'test'} | ${15}
+    ${'the test name'} | ${'test'} | ${10}
+    ${'the test name'} | ${'test'} | ${5}
+    ${'the test name'} | ${'name'} | ${30}
+    ${'the test name'} | ${'name'} | ${25}
+    ${'the test name'} | ${'name'} | ${20}
+    ${'the test name'} | ${'name'} | ${15}
+    ${'the test name'} | ${'name'} | ${10}
+    ${'the test name'} | ${'name'} | ${5}
+  `(
+    'formats when testname="$testName", pattern="$pattern", and width="$width"',
+    ({ testName, pattern, width }) => {
+      expect(
+        formatTestNameByPattern(testName, pattern, width),
+      ).toMatchSnapshot();
+    },
+  );
 });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -138,22 +138,49 @@ export const formatTestNameByPattern = (
     return colorize(inlineTestName, startPatternIndex, endPatternIndex);
   }
 
-  const slicedTestName = inlineTestName.slice(0, width - DOTS.length);
+  const slicedTestName = inlineTestName.slice(-width + DOTS.length);
+  const numberOfTruncatedChars = inlineTestName.length - slicedTestName.length;
 
-  if (startPatternIndex < slicedTestName.length) {
-    if (endPatternIndex > slicedTestName.length) {
-      return colorize(
-        slicedTestName + DOTS,
-        startPatternIndex,
-        slicedTestName.length + DOTS.length,
-      );
-    }
-    return colorize(
-      slicedTestName + DOTS,
-      Math.min(startPatternIndex, slicedTestName.length),
+  if (pattern === 'test' && width === 10) {
+    console.log({
+      inlineTestName,
+      pattern,
+      width,
+      slicedTestName,
+      startPatternIndex,
       endPatternIndex,
+      slicedTestNameLength: slicedTestName.length,
+      numberOfTruncatedChars,
+      finalString: DOTS + slicedTestName,
+      finalStringLength: (DOTS + slicedTestName).length,
+      start: startPatternIndex - numberOfTruncatedChars + DOTS.length,
+      end: endPatternIndex - numberOfTruncatedChars + DOTS.length,
+    });
+  }
+
+  // The pattern maches in both the visible and truncated sections
+  if (
+    startPatternIndex <= numberOfTruncatedChars &&
+    endPatternIndex >= numberOfTruncatedChars
+  ) {
+    return colorize(
+      DOTS + slicedTestName,
+      0,
+      endPatternIndex - numberOfTruncatedChars + DOTS.length,
     );
   }
 
-  return `${chalk.dim(slicedTestName)}${chalk.reset(DOTS)}`;
+  // The pattern maches in the truncated section only
+  if (startPatternIndex <= numberOfTruncatedChars) {
+    return `${chalk.reset(DOTS)}${chalk.dim(slicedTestName)}`;
+  }
+
+  // The pattern maches in the visible section only
+  if (startPatternIndex > numberOfTruncatedChars) {
+    return colorize(
+      DOTS + slicedTestName,
+      startPatternIndex - numberOfTruncatedChars + DOTS.length,
+      endPatternIndex - numberOfTruncatedChars + DOTS.length,
+    );
+  }
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -134,19 +134,24 @@ export const formatTestNameByPattern = (
   const startPatternIndex = Math.max(match.index, 0);
   const endPatternIndex = startPatternIndex + match[0].length;
 
-  if (inlineTestName.length <= width) {
+  const testNameFitsInTerminal = inlineTestName.length <= width;
+  if (testNameFitsInTerminal) {
     return colorize(inlineTestName, startPatternIndex, endPatternIndex);
   }
 
-  const slicedTestName = inlineTestName.slice(-width + DOTS.length);
-  const numberOfTruncatedChars = inlineTestName.length - slicedTestName.length;
+  const numberOfTruncatedChars = DOTS.length + inlineTestName.length - width;
+  const end = Math.max(endPatternIndex - numberOfTruncatedChars, 0);
+  const truncatedTestName = inlineTestName.slice(numberOfTruncatedChars);
+
   const shouldHighlightDots = startPatternIndex <= numberOfTruncatedChars;
+  if (shouldHighlightDots) {
+    return colorize(DOTS + truncatedTestName, 0, end + DOTS.length);
+  }
 
-  const start = shouldHighlightDots
-    ? 0
-    : startPatternIndex - numberOfTruncatedChars + DOTS.length;
-  const end =
-    Math.max(endPatternIndex - numberOfTruncatedChars, 0) + DOTS.length;
-
-  return colorize(DOTS + slicedTestName, start, end);
+  const start = startPatternIndex - numberOfTruncatedChars;
+  return colorize(
+    DOTS + truncatedTestName,
+    start + DOTS.length,
+    end + DOTS.length,
+  );
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -140,47 +140,13 @@ export const formatTestNameByPattern = (
 
   const slicedTestName = inlineTestName.slice(-width + DOTS.length);
   const numberOfTruncatedChars = inlineTestName.length - slicedTestName.length;
+  const shouldHighlightDots = startPatternIndex <= numberOfTruncatedChars;
 
-  if (pattern === 'test' && width === 10) {
-    console.log({
-      inlineTestName,
-      pattern,
-      width,
-      slicedTestName,
-      startPatternIndex,
-      endPatternIndex,
-      slicedTestNameLength: slicedTestName.length,
-      numberOfTruncatedChars,
-      finalString: DOTS + slicedTestName,
-      finalStringLength: (DOTS + slicedTestName).length,
-      start: startPatternIndex - numberOfTruncatedChars + DOTS.length,
-      end: endPatternIndex - numberOfTruncatedChars + DOTS.length,
-    });
-  }
+  const start = shouldHighlightDots
+    ? 0
+    : startPatternIndex - numberOfTruncatedChars + DOTS.length;
+  const end =
+    Math.max(endPatternIndex - numberOfTruncatedChars, 0) + DOTS.length;
 
-  // The pattern maches in both the visible and truncated sections
-  if (
-    startPatternIndex <= numberOfTruncatedChars &&
-    endPatternIndex >= numberOfTruncatedChars
-  ) {
-    return colorize(
-      DOTS + slicedTestName,
-      0,
-      endPatternIndex - numberOfTruncatedChars + DOTS.length,
-    );
-  }
-
-  // The pattern maches in the truncated section only
-  if (startPatternIndex <= numberOfTruncatedChars) {
-    return `${chalk.reset(DOTS)}${chalk.dim(slicedTestName)}`;
-  }
-
-  // The pattern maches in the visible section only
-  if (startPatternIndex > numberOfTruncatedChars) {
-    return colorize(
-      DOTS + slicedTestName,
-      startPatternIndex - numberOfTruncatedChars + DOTS.length,
-      endPatternIndex - numberOfTruncatedChars + DOTS.length,
-    );
-  }
+  return colorize(DOTS + slicedTestName, start, end);
 };


### PR DESCRIPTION
This PR adds a better truncation strategy for the test name typeahead. Now that we are showing the describe blocks the text can be really long

We should truncate the start of the test name instead of the end, given that the end of the test name is the "it/test" description, which tends to be more relevant and specific.

This is similar to how the filename plugin works, where it truncates the first directories, but not the filename.

#### Before
![aaaa-bfore](https://user-images.githubusercontent.com/574806/54471441-34428b00-4776-11e9-9a10-2a688bf7d6a0.gif)
#### After
![aaaa](https://user-images.githubusercontent.com/574806/54471442-34428b00-4776-11e9-86ff-50b2b80fcf27.gif)
