### PR TITLE
Remove build directory before building to avoid old artifacts being published

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "jest",
     "lint": "eslint .",
     "watch": "babel src -w --ignore **/*.test.js,integration -d build",
+    "prebuild": "rimraf build",
     "build": "babel src --ignore **/*.test.js,integration -d build",
     "prepublish": "yarn build",
     "format": "prettier --single-quote --trailing-comma all --write \"!(build)/**/*.js\""
@@ -48,7 +49,8 @@
     "eslint-plugin-prettier": "^3.0.1",
     "flow-bin": "^0.105.2",
     "jest": "^24.3.0",
-    "prettier": "^1.13.7"
+    "prettier": "^1.13.7",
+    "rimraf": "^3.0.0"
   },
   "jest": {
     "watchPlugins": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4202,6 +4202,13 @@ rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"


### PR DESCRIPTION
0.2.1 had old & new artifacts published:
<img width="237" alt="Screenshot 2019-11-07 at 12 48 51" src="https://user-images.githubusercontent.com/9800850/68386784-11c60d80-015d-11ea-86e8-0ded69014837.png">

The current 0.4.0 doesn't suffer from this problem - but this helps to avoid this problem in the future.