### PR TITLE
Provide exact pattern for selected test names

### DIFF
--- a/src/file_name_plugin/plugin.js
+++ b/src/file_name_plugin/plugin.js
@@ -1,9 +1,7 @@
 // @flow
 
 import { Prompt } from 'jest-watcher';
-import { escapeStrForRegex } from 'jest-regex-util';
 import FileNamePatternPrompt, { type SearchSources } from './prompt';
-import { removeTrimmingDots } from '../lib/utils';
 
 type PluginConfig = {
   key?: string,
@@ -54,13 +52,10 @@ class FileNamePlugin {
     const p = new FileNamePatternPrompt(this._stdout, this._prompt);
     p.updateSearchSources(this._projects);
     return new Promise((res, rej) => {
-      p.run((value) => {
+      p.run((testPathPattern) => {
         updateConfigAndRun({
           mode: 'watch',
-          testPathPattern: removeTrimmingDots(value)
-            .split('/')
-            .map(escapeStrForRegex)
-            .join('/'),
+          testPathPattern,
         });
         res();
       }, rej);

--- a/src/file_name_plugin/prompt.js
+++ b/src/file_name_plugin/prompt.js
@@ -9,7 +9,13 @@ import {
   printPatternCaret,
   printRestoredPatternCaret,
 } from 'jest-watcher';
-import { highlight, getTerminalWidth, trimAndFormatPath } from '../lib/utils';
+import { escapeStrForRegex } from 'jest-regex-util';
+import {
+  highlight,
+  getTerminalWidth,
+  trimAndFormatPath,
+  removeTrimmingDots,
+} from '../lib/utils';
 import {
   formatTypeaheadSelection,
   printMore,
@@ -85,7 +91,10 @@ export default class FileNamePatternPrompt extends PatternPrompt {
 
   _getMatchedTests(
     pattern: string,
-  ): Array<{ path: string, context: { config: ProjectConfig } }> {
+  ): Array<{
+    path: string,
+    context: { config: ProjectConfig },
+  }> {
     let regex;
 
     try {
@@ -108,5 +117,17 @@ export default class FileNamePatternPrompt extends PatternPrompt {
 
   updateSearchSources(searchSources: SearchSources) {
     this._searchSources = searchSources;
+  }
+
+  run(onSuccess: Function, onCancel: Function, options: Object) {
+    super.run(
+      (value) => {
+        onSuccess(
+          removeTrimmingDots(value).split('/').map(escapeStrForRegex).join('/'),
+        );
+      },
+      onCancel,
+      options,
+    );
   }
 }

--- a/src/test_name_plugin/__tests__/plugin.test.js
+++ b/src/test_name_plugin/__tests__/plugin.test.js
@@ -60,7 +60,7 @@ it('can use arrows to select a specific test', async () => {
 
   expect(updateConfigAndRun).toHaveBeenCalledWith({
     mode: 'watch',
-    testNamePattern: 'other description foo 2',
+    testNamePattern: '^other description foo 2$',
   });
 });
 
@@ -132,7 +132,7 @@ it('can select a pattern that includes a regexp special character', async () => 
 
   expect(updateConfigAndRun).toHaveBeenCalledWith({
     mode: 'watch',
-    testNamePattern: 'bracket description \\(foo\\)',
+    testNamePattern: '^bracket description \\(foo\\)$',
   });
 });
 
@@ -196,6 +196,6 @@ it("selected pattern doesn't include trimming dots", async () => {
 
   expect(updateConfigAndRun).toHaveBeenCalledWith({
     mode: 'watch',
-    testNamePattern: 'me, gonna need trimming',
+    testNamePattern: '^me, gonna need trimming$',
   });
 });

--- a/src/test_name_plugin/plugin.js
+++ b/src/test_name_plugin/plugin.js
@@ -1,9 +1,7 @@
 // @flow
 
 import { Prompt } from 'jest-watcher';
-import { escapeStrForRegex } from 'jest-regex-util';
 import TestNamePatternPrompt, { type TestResult } from './prompt';
-import { removeTrimmingDots } from '../lib/utils';
 
 type PluginConfig = {
   key?: string,
@@ -54,13 +52,10 @@ class TestNamePlugin {
     const p = new TestNamePatternPrompt(this._stdout, this._prompt);
     p.updateCachedTestResults(this._testResults);
     return new Promise((res, rej) => {
-      p.run((value, { useExactMatch }) => {
-        const preparedPattern = escapeStrForRegex(removeTrimmingDots(value));
+      p.run((testNamePattern) => {
         updateConfigAndRun({
           mode: 'watch',
-          testNamePattern: useExactMatch
-            ? `^${preparedPattern}$`
-            : preparedPattern,
+          testNamePattern,
         });
         res();
       }, rej);

--- a/src/test_name_plugin/plugin.js
+++ b/src/test_name_plugin/plugin.js
@@ -54,10 +54,13 @@ class TestNamePlugin {
     const p = new TestNamePatternPrompt(this._stdout, this._prompt);
     p.updateCachedTestResults(this._testResults);
     return new Promise((res, rej) => {
-      p.run((value) => {
+      p.run((value, { useExactMatch }) => {
+        const preparedPattern = escapeStrForRegex(removeTrimmingDots(value));
         updateConfigAndRun({
           mode: 'watch',
-          testNamePattern: escapeStrForRegex(removeTrimmingDots(value)),
+          testNamePattern: useExactMatch
+            ? `^${preparedPattern}$`
+            : preparedPattern,
         });
         res();
       }, rej);

--- a/src/test_name_plugin/prompt.js
+++ b/src/test_name_plugin/prompt.js
@@ -27,14 +27,18 @@ export type TestResult = {
 class TestNamePatternPrompt extends PatternPrompt {
   _cachedTestResults: Array<TestResult>;
 
+  _offset: number;
+
   constructor(pipe: stream$Writable | tty$WriteStream, prompt: Prompt) {
     super(pipe, prompt);
     this._entityName = 'tests';
     this._cachedTestResults = [];
+    this._offset = -1;
   }
 
   _onChange(pattern: string, options: ScrollOptions) {
     super._onChange(pattern, options);
+    this._offset = options.offset;
     this._printTypeahead(pattern, options);
   }
 
@@ -97,6 +101,16 @@ class TestNamePatternPrompt extends PatternPrompt {
 
   updateCachedTestResults(testResults: Array<TestResult> = []) {
     this._cachedTestResults = testResults;
+  }
+
+  run(onSuccess: Function, onCancel: Function, options: Object) {
+    super.run(
+      (value) => {
+        onSuccess(value, { useExactMatch: this._offset !== -1 });
+      },
+      onCancel,
+      options,
+    );
   }
 }
 

--- a/src/test_name_plugin/prompt.js
+++ b/src/test_name_plugin/prompt.js
@@ -8,8 +8,13 @@ import {
   printPatternCaret,
   printRestoredPatternCaret,
 } from 'jest-watcher';
+import { escapeStrForRegex } from 'jest-regex-util';
 import scroll, { type ScrollOptions } from '../lib/scroll';
-import { formatTestNameByPattern, getTerminalWidth } from '../lib/utils';
+import {
+  formatTestNameByPattern,
+  getTerminalWidth,
+  removeTrimmingDots,
+} from '../lib/utils';
 import {
   formatTypeaheadSelection,
   printMore,
@@ -106,7 +111,9 @@ class TestNamePatternPrompt extends PatternPrompt {
   run(onSuccess: Function, onCancel: Function, options: Object) {
     super.run(
       (value) => {
-        onSuccess(value, { useExactMatch: this._offset !== -1 });
+        const preparedPattern = escapeStrForRegex(removeTrimmingDots(value));
+        const useExactMatch = this._offset !== -1;
+        onSuccess(useExactMatch ? `^${preparedPattern}$` : preparedPattern);
       },
       onCancel,
       options,


### PR DESCRIPTION
closes #38 

I don't fully understand the interaction between `Prompt`, `TestNamePlugin`, and `TestNamePatternPrompt` - or maybe rather: I don't fully understand the design behind it. From what I have understood though, there is no super straightforward way to do this - I had to inherit `run` so I could call `onSuccess` with a piece of extra information as it was just not provided at all by the base class. That extra information (`useExactMatch`) is based on `offset` provided by `onChange` which reflects the highlighted option so it quite directly means if we should use exact match or not.

Alternatively, we could move the whole "preparing" of the `testNamePattern` to the `TestNamePatternPrompt` (and then do the similar change in `FileNamePatternPrompt`). When I think about it now - it seems more logical to me and I think I would prefer such a solution. Can adjust the PR later if you'd like this. Thoughts?