### PR TITLE
chore: bump `jest-serializer-ansi-escapes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-jest": "^26.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^28.0.0",
-    "jest-serializer-ansi-escapes": "^1.0.1",
+    "jest-serializer-ansi-escapes": "^2.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
     "semantic-release": "^19.0.3",

--- a/src/file_name_plugin/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/src/file_name_plugin/__tests__/__snapshots__/plugin.test.ts.snap
@@ -4,33 +4,33 @@ exports[`can select a pattern that matches multiple files 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> f
+<dim> pattern ›</intensity> f
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
  Pattern matches 3 files
 
- <dim>›</> <dim>src/</></>f</><dim>oo.js</>
+ <dim>›</intensity> <dim>src/</intensity></>f</><dim>oo.js</intensity>
 
- <dim>›</> <dim>src/</></>f</><dim>ile-1.js</>
+ <dim>›</intensity> <dim>src/</intensity></>f</><dim>ile-1.js</intensity>
 
- <dim>›</> <dim>src/</></>f</><dim>ile-2.js</>
+ <dim>›</intensity> <dim>src/</intensity></>f</><dim>ile-2.js</intensity>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> fi
+<dim> pattern ›</intensity> fi
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
  Pattern matches 2 files
 
- <dim>›</> <dim>src/</></>fi</><dim>le-1.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-1.js</intensity>
 
- <dim>›</> <dim>src/</></>fi</><dim>le-2.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-2.js</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 "
@@ -40,48 +40,48 @@ exports[`can use arrows to select a specific file 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> f
+<dim> pattern ›</intensity> f
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
  Pattern matches 3 files
 
- <dim>›</> <dim>src/</></>f</><dim>oo.js</>
+ <dim>›</intensity> <dim>src/</intensity></>f</><dim>oo.js</intensity>
 
- <dim>›</> <dim>src/</></>f</><dim>ile-1.js</>
+ <dim>›</intensity> <dim>src/</intensity></>f</><dim>ile-1.js</intensity>
 
- <dim>›</> <dim>src/</></>f</><dim>ile-2.js</>
+ <dim>›</intensity> <dim>src/</intensity></>f</><dim>ile-2.js</intensity>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> fi
+<dim> pattern ›</intensity> fi
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
  Pattern matches 2 files
 
- <dim>›</> <dim>src/</></>fi</><dim>le-1.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-1.js</intensity>
 
- <dim>›</> <dim>src/</></>fi</><dim>le-2.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-2.js</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> fi
+<dim> pattern ›</intensity> fi
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
  Pattern matches 2 files
 
- <dim>›</> <black><backgroundYellow>src/file-1.js</></>
+ <dim>›</intensity> <black><backgroundYellow>src/file-1.js</background></color>
 
- <dim>›</> <dim>src/</></>fi</><dim>le-2.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-2.js</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 "
@@ -91,16 +91,16 @@ exports[`file matching is case insensitive 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> fI
+<dim> pattern ›</intensity> fI
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
  Pattern matches 2 files
 
- <dim>›</> <dim>src/</></>fi</><dim>le-1.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-1.js</intensity>
 
- <dim>›</> <dim>src/</></>fi</><dim>le-2.js</>
+ <dim>›</intensity> <dim>src/</intensity></>fi</><dim>le-2.js</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 "
@@ -110,21 +110,21 @@ exports[`shows the correct initial state 1`] = `
 "<hideCursor>
 <clearTerminal>
 
-<bold>Pattern Mode Usage</>
- <dim>› Press</> Esc <dim>to exit pattern mode.</>
- <dim>› Press</> Enter <dim>to filter by a filenames regex pattern.</>
+<bold>Pattern Mode Usage</intensity>
+ <dim>› Press</intensity> Esc <dim>to exit pattern mode.</intensity>
+ <dim>› Press</intensity> Enter <dim>to filter by a filenames regex pattern.</intensity>
 
 
 <showCursor>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> 
+<dim> pattern ›</intensity> 
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- <italic><yellow>Start typing to filter by a filename regex pattern.</></>
+ <italic><yellow>Start typing to filter by a filename regex pattern.</color></italic>
 <moveCursorToRow6Column12>
 <restoreCursorPosition>
 "

--- a/src/lib/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/utils.test.ts.snap
@@ -2,44 +2,44 @@
 
 exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="5" 1`] = `"</>...me</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="10" 1`] = `"<dim>...st </></>name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="10" 1`] = `"<dim>...st </intensity></>name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="15" 1`] = `"<dim>the test </></>name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="15" 1`] = `"<dim>the test </intensity></>name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="20" 1`] = `"<dim>the test </></>name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="20" 1`] = `"<dim>the test </intensity></>name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="25" 1`] = `"<dim>the test </></>name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="25" 1`] = `"<dim>the test </intensity></>name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="30" 1`] = `"<dim>the test </></>name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="name", and width="30" 1`] = `"<dim>the test </intensity></>name</>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="5" 1`] = `"</>...</><dim>me</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="5" 1`] = `"</>...</><dim>me</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="10" 1`] = `"</>...st</><dim> name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="10" 1`] = `"</>...st</><dim> name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="15" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="15" 1`] = `"<dim>the </intensity></>test</><dim> name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="20" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="20" 1`] = `"<dim>the </intensity></>test</><dim> name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="25" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="25" 1`] = `"<dim>the </intensity></>test</><dim> name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="30" 1`] = `"<dim>the </></>test</><dim> name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="test", and width="30" 1`] = `"<dim>the </intensity></>test</><dim> name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="5" 1`] = `"</>...</><dim>me</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="5" 1`] = `"</>...</><dim>me</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="10" 1`] = `"</>...</><dim>st name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="10" 1`] = `"</>...</><dim>st name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="15" 1`] = `"</>the</><dim> test name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="15" 1`] = `"</>the</><dim> test name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="20" 1`] = `"</>the</><dim> test name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="20" 1`] = `"</>the</><dim> test name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="25" 1`] = `"</>the</><dim> test name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="25" 1`] = `"</>the</><dim> test name</intensity>"`;
 
-exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="30" 1`] = `"</>the</><dim> test name</>"`;
+exports[`formatTestNameByPattern formats when testname="the test name", pattern="the", and width="30" 1`] = `"</>the</><dim> test name</intensity>"`;
 
-exports[`trimAndFormatPath formats when testpath="/project/src/exactly/sep_and_basename.js", pad="6", and columns="29" 1`] = `"<dim>.../</><bold>sep_and_basename.js</>"`;
+exports[`trimAndFormatPath formats when testpath="/project/src/exactly/sep_and_basename.js", pad="6", and columns="29" 1`] = `"<dim>.../</intensity><bold>sep_and_basename.js</intensity>"`;
 
-exports[`trimAndFormatPath formats when testpath="/project/src/gonna/fit/all.js", pad="6", and columns="80" 1`] = `"<dim>src/gonna/fit/</><bold>all.js</>"`;
+exports[`trimAndFormatPath formats when testpath="/project/src/gonna/fit/all.js", pad="6", and columns="80" 1`] = `"<dim>src/gonna/fit/</intensity><bold>all.js</intensity>"`;
 
-exports[`trimAndFormatPath formats when testpath="/project/src/long_name_gonna_need_trimming.js", pad="6", and columns="40" 1`] = `"<bold>...ong_name_gonna_need_trimming.js</>"`;
+exports[`trimAndFormatPath formats when testpath="/project/src/long_name_gonna_need_trimming.js", pad="6", and columns="40" 1`] = `"<bold>...ong_name_gonna_need_trimming.js</intensity>"`;
 
-exports[`trimAndFormatPath formats when testpath="/project/src/trimmed_dir/foo.js", pad="6", and columns="20" 1`] = `"<dim>..._dir/</><bold>foo.js</>"`;
+exports[`trimAndFormatPath formats when testpath="/project/src/trimmed_dir/foo.js", pad="6", and columns="20" 1`] = `"<dim>..._dir/</intensity><bold>foo.js</intensity>"`;

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -72,7 +72,7 @@ describe('highlight', () => {
     );
 
     expect(highlight(rawPath, filePath, pattern)).toMatchInlineSnapshot(
-      `"<dim>__tests__/utils/experimentation/entry-point/</></>parse</><dim>EntryPoint.test.js</>"`,
+      `"<dim>__tests__/utils/experimentation/entry-point/</intensity></>parse</><dim>EntryPoint.test.js</intensity>"`,
     );
   });
 
@@ -82,7 +82,7 @@ describe('highlight', () => {
     );
 
     expect(highlight(rawPath, filePath, pattern)).toMatchInlineSnapshot(
-      `"<dim>...tils/experimentation/entry-point/</></>parse</><dim>EntryPoint.test.js</>"`,
+      `"<dim>...tils/experimentation/entry-point/</intensity></>parse</><dim>EntryPoint.test.js</intensity>"`,
     );
   });
 
@@ -92,7 +92,7 @@ describe('highlight', () => {
     );
 
     expect(highlight(rawPath, filePath, pattern)).toMatchInlineSnapshot(
-      `"<dim>./src/__tests__/utils/experimentation/entry-point/</></>parse</><dim>EntryPoint.test.js</>"`,
+      `"<dim>./src/__tests__/utils/experimentation/entry-point/</intensity></>parse</><dim>EntryPoint.test.js</intensity>"`,
     );
   });
 });

--- a/src/test_name_plugin/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/src/test_name_plugin/__tests__/__snapshots__/plugin.test.ts.snap
@@ -4,35 +4,35 @@ exports[`can select a pattern that matches a describe block 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> s
+<dim> pattern ›</intensity> s
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 4 tests from <yellow>cached</> test suites
+ Pattern matches 4 tests from <yellow>cached</color> test suites
 
- <dim>›</> </>s</><dim>ome description foo 1</>
+ <dim>›</intensity> </>s</><dim>ome description foo 1</intensity>
 
- <dim>›</> </>s</><dim>ome description bar 1</>
+ <dim>›</intensity> </>s</><dim>ome description bar 1</intensity>
 
- <dim>›</> <dim>other de</></>s</><dim>cription foo 2</>
+ <dim>›</intensity> <dim>other de</intensity></>s</><dim>cription foo 2</intensity>
 
- <dim>›</> <dim>other de</></>s</><dim>cription bar 2</>
+ <dim>›</intensity> <dim>other de</intensity></>s</><dim>cription bar 2</intensity>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> so
+<dim> pattern ›</intensity> so
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> </>so</><dim>me description foo 1</>
+ <dim>›</intensity> </>so</><dim>me description foo 1</intensity>
 
- <dim>›</> </>so</><dim>me description bar 1</>
+ <dim>›</intensity> </>so</><dim>me description bar 1</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 "
@@ -42,31 +42,31 @@ exports[`can select a pattern that matches multiple tests 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> f
+<dim> pattern ›</intensity> f
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> <dim>some description </></>f</><dim>oo 1</>
+ <dim>›</intensity> <dim>some description </intensity></>f</><dim>oo 1</intensity>
 
- <dim>›</> <dim>other description </></>f</><dim>oo 2</>
+ <dim>›</intensity> <dim>other description </intensity></>f</><dim>oo 2</intensity>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> fo
+<dim> pattern ›</intensity> fo
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> <dim>some description </></>fo</><dim>o 1</>
+ <dim>›</intensity> <dim>some description </intensity></>fo</><dim>o 1</intensity>
 
- <dim>›</> <dim>other description </></>fo</><dim>o 2</>
+ <dim>›</intensity> <dim>other description </intensity></>fo</><dim>o 2</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 "
@@ -76,46 +76,46 @@ exports[`can use arrows to select a specific test 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> f
+<dim> pattern ›</intensity> f
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> <dim>some description </></>f</><dim>oo 1</>
+ <dim>›</intensity> <dim>some description </intensity></>f</><dim>oo 1</intensity>
 
- <dim>›</> <dim>other description </></>f</><dim>oo 2</>
+ <dim>›</intensity> <dim>other description </intensity></>f</><dim>oo 2</intensity>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> f
+<dim> pattern ›</intensity> f
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> <black><backgroundYellow>some description foo 1</></>
+ <dim>›</intensity> <black><backgroundYellow>some description foo 1</background></color>
 
- <dim>›</> <dim>other description </></>f</><dim>oo 2</>
+ <dim>›</intensity> <dim>other description </intensity></>f</><dim>oo 2</intensity>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> f
+<dim> pattern ›</intensity> f
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> <dim>some description </></>f</><dim>oo 1</>
+ <dim>›</intensity> <dim>some description </intensity></>f</><dim>oo 1</intensity>
 
- <dim>›</> <black><backgroundYellow>other description foo 2</></>
+ <dim>›</intensity> <black><backgroundYellow>other description foo 2</background></color>
 <moveCursorToRow6Column13>
 <restoreCursorPosition>
 "
@@ -125,21 +125,21 @@ exports[`shows the correct initial state 1`] = `
 "<hideCursor>
 <clearTerminal>
 
-<bold>Pattern Mode Usage</>
- <dim>› Press</> Esc <dim>to exit pattern mode.</>
- <dim>› Press</> Enter <dim>to filter by a tests regex pattern.</>
+<bold>Pattern Mode Usage</intensity>
+ <dim>› Press</intensity> Esc <dim>to exit pattern mode.</intensity>
+ <dim>› Press</intensity> Enter <dim>to filter by a tests regex pattern.</intensity>
 
 
 <showCursor>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> 
+<dim> pattern ›</intensity> 
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- <italic><yellow>Start typing to filter by a test name regex pattern.</></>
+ <italic><yellow>Start typing to filter by a test name regex pattern.</color></italic>
 <moveCursorToRow6Column12>
 <restoreCursorPosition>
 "
@@ -149,21 +149,21 @@ exports[`shows the correct message when there are no cached tests 1`] = `
 "<hideCursor>
 <clearTerminal>
 
-<bold>Pattern Mode Usage</>
- <dim>› Press</> Esc <dim>to exit pattern mode.</>
- <dim>› Press</> Enter <dim>to filter by a tests regex pattern.</>
+<bold>Pattern Mode Usage</intensity>
+ <dim>› Press</intensity> Esc <dim>to exit pattern mode.</intensity>
+ <dim>› Press</intensity> Enter <dim>to filter by a tests regex pattern.</intensity>
 
 
 <showCursor>
 <eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> 
+<dim> pattern ›</intensity> 
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- <italic><yellow>Start typing to filter by a test name regex pattern.</></>
+ <italic><yellow>Start typing to filter by a test name regex pattern.</color></italic>
 <moveCursorToRow6Column12>
 <restoreCursorPosition>
 "
@@ -173,16 +173,16 @@ exports[`test matching is case insensitive 1`] = `
 "<eraseLine>
 <moveCursorToColumn1>
 <eraseScreenDown>
-<dim> pattern ›</> fO
+<dim> pattern ›</intensity> fO
 <saveCursorPosition>
 <moveCursorToColumn1>
 
 
- Pattern matches 2 tests from <yellow>cached</> test suites
+ Pattern matches 2 tests from <yellow>cached</color> test suites
 
- <dim>›</> <dim>some description </></>fo</><dim>o 1</>
+ <dim>›</intensity> <dim>some description </intensity></>fo</><dim>o 1</intensity>
 
- <dim>›</> <dim>other description </></>fo</><dim>o 2</>
+ <dim>›</intensity> <dim>other description </intensity></>fo</><dim>o 2</intensity>
 <moveCursorToRow6Column14>
 <restoreCursorPosition>
 "

--- a/yarn.lock
+++ b/yarn.lock
@@ -4202,10 +4202,10 @@ jest-runtime@^28.1.2:
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-serializer-ansi-escapes@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer-ansi-escapes/-/jest-serializer-ansi-escapes-1.0.1.tgz#4c26adb7e5d4cd382f7adeb32cf5b12a4ac27d96"
-  integrity sha512-qfDZgNHLXVVFwsAGD8obs1KirQG43K5N0zwDMmaXL8HkS1PcPMZosofp1eykETPPJMY+pQSZkprXPq120WMJtQ==
+jest-serializer-ansi-escapes@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer-ansi-escapes/-/jest-serializer-ansi-escapes-2.0.1.tgz#053fc7f2d8629ad127afb6a31e542b65c6ad7806"
+  integrity sha512-+BuVKZQutcejSuODTleG/CV+8OVONZSOSrtrQRG8isTLu367JVKK+/yaG2jGs5O6MPBZ88WNy5jg8hqhd/p6pw==
 
 jest-snapshot@^28.1.2:
   version "28.1.2"


### PR DESCRIPTION
Closes #163

This PR is upgrading `jest-serializer-ansi-escapes` to v2.

Version 2 of the plugin introduced better serialization for reset sequences. For instance, a snapshot like `<red>first<bold>second</>third</>` becomes `<red>first<bold>second</intensity>third</color>`.