### PR TITLE
feat: support Jest 30

### DIFF
--- a/src/file_name_plugin/__tests__/plugin.test.ts
+++ b/src/file_name_plugin/__tests__/plugin.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, expect, it } from '@jest/globals';
-import { KEYS } from 'jest-watcher';
+import jestWatcher from 'jest-watcher';
 import type { Config } from '@jest/types';
+
+const { KEYS } = jestWatcher;
 
 let pluginTester: typeof import('../../test_utils/pluginTester').default = null;
 let FileNamePlugin: typeof import('../plugin').default = null;

--- a/src/file_name_plugin/plugin.ts
+++ b/src/file_name_plugin/plugin.ts
@@ -1,6 +1,5 @@
-import {
+import jestWatcher, {
   type WatchPlugin,
-  Prompt,
   type JestHookSubscriber,
   type UpdateConfigCallback,
   type UsageData,
@@ -9,12 +8,14 @@ import type { Config } from '@jest/types';
 import FileNamePatternPrompt, { type SearchSources } from './prompt';
 import type { PluginConfig } from '../types/Config';
 
+const { Prompt } = jestWatcher;
+
 export default class FileNamePlugin implements WatchPlugin {
   _stdin: NodeJS.ReadStream;
 
   _stdout: NodeJS.WriteStream;
 
-  _prompt: Prompt;
+  _prompt: jestWatcher.Prompt;
 
   _projects: SearchSources;
 

--- a/src/file_name_plugin/prompt.ts
+++ b/src/file_name_plugin/prompt.ts
@@ -1,13 +1,8 @@
 import chalk from 'chalk';
 import ansiEscapes from 'ansi-escapes';
 import stringLength from 'string-length';
-import {
-  type Prompt,
-  PatternPrompt,
-  printPatternCaret,
-  printRestoredPatternCaret,
-} from 'jest-watcher';
-import { escapeStrForRegex } from 'jest-regex-util';
+import jestWatcher, { type Prompt } from 'jest-watcher';
+import jestRegexUtil from 'jest-regex-util';
 import type { Config } from '@jest/types';
 import {
   highlight,
@@ -28,6 +23,11 @@ export type SearchSources = Array<{
   config: Config.ProjectConfig;
   testPaths: Array<string>;
 }>;
+
+const { PatternPrompt, printPatternCaret, printRestoredPatternCaret } =
+  jestWatcher;
+
+const { escapeStrForRegex } = jestRegexUtil;
 
 export default class FileNamePatternPrompt extends PatternPrompt {
   _searchSources: SearchSources;

--- a/src/test_name_plugin/plugin.ts
+++ b/src/test_name_plugin/plugin.ts
@@ -1,5 +1,4 @@
-import {
-  Prompt,
+import jestWatcher, {
   type WatchPlugin,
   type JestHookSubscriber,
   type UpdateConfigCallback,
@@ -15,7 +14,7 @@ export default class TestNamePlugin implements WatchPlugin {
 
   _stdout: NodeJS.WriteStream;
 
-  _prompt: Prompt;
+  _prompt: jestWatcher.Prompt;
 
   _testResults: Array<TestResult>;
 
@@ -32,7 +31,7 @@ export default class TestNamePlugin implements WatchPlugin {
   }) {
     this._stdin = stdin;
     this._stdout = stdout;
-    this._prompt = new Prompt();
+    this._prompt = new jestWatcher.Prompt();
     this._testResults = [];
     this._usageInfo = {
       key: config.key || 't',

--- a/src/test_name_plugin/prompt.ts
+++ b/src/test_name_plugin/prompt.ts
@@ -1,13 +1,8 @@
 import chalk from 'chalk';
 import ansiEscapes from 'ansi-escapes';
-import {
-  type Prompt,
-  PatternPrompt,
-  printPatternCaret,
-  printRestoredPatternCaret,
-} from 'jest-watcher';
+import jestWatcher, { type Prompt } from 'jest-watcher';
 import type { TestResult } from '@jest/test-result';
-import { escapeStrForRegex } from 'jest-regex-util';
+import jestRegexUtil from 'jest-regex-util';
 import scroll, { type ScrollOptions } from '../lib/scroll';
 import {
   formatTestNameByPattern,
@@ -21,6 +16,10 @@ import {
   printStartTyping,
   printTypeaheadItem,
 } from '../lib/pattern_mode_helpers';
+
+const { PatternPrompt, printPatternCaret, printRestoredPatternCaret } =
+  jestWatcher;
+const { escapeStrForRegex } = jestRegexUtil;
 
 export default class TestNamePatternPrompt extends PatternPrompt {
   _cachedTestResults: Array<TestResult>;

--- a/src/test_utils/pluginTester.ts
+++ b/src/test_utils/pluginTester.ts
@@ -1,5 +1,4 @@
-import {
-  JestHook,
+import jestWatcher, {
   type WatchPlugin,
   type JestHookEmitter,
   type UpdateConfigCallback,
@@ -13,6 +12,8 @@ type Options = {
   stdout?: { columns?: number };
   config?: PluginConfig;
 };
+
+const { JestHook } = jestWatcher;
 
 export default function pluginTester(
   Plugin: typeof TestNamePlugin | typeof FileNamePlugin,


### PR DESCRIPTION
Due to https://github.com/nodejs/cjs-module-lexer/issues/88, the named imports don't work.

Thankfully, TS knows the exports are also available on the `default` export, so we can just migrate to that.

---

In draft until Jest 30 is actually released