### PR TITLE
refactor (deps): replace strip-ansi with native stripVTControlCharacters from node:util

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "jest-regex-util": "^30.0.0",
     "jest-watcher": "^30.0.0",
     "slash": "^5.0.0",
-    "string-length": "^6.0.0",
-    "strip-ansi": "^7.0.1"
+    "string-length": "^6.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/lib/pattern_mode_helpers.ts
+++ b/src/lib/pattern_mode_helpers.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
 import type { Prompt } from 'jest-watcher';
 
 const pluralize = (count: number, text: string) =>
@@ -54,8 +54,8 @@ export const formatTypeaheadSelection = (
   prompt: Prompt,
 ): string => {
   if (index === activeIndex) {
-    prompt.setPromptSelection(stripAnsi(item));
-    return chalk.black.bgYellow(stripAnsi(item));
+    prompt.setPromptSelection(stripVTControlCharacters(item));
+    return chalk.black.bgYellow(stripVTControlCharacters(item));
   }
   return item;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import slash from 'slash';
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
 import type { Config } from '@jest/types';
 
 const TRIMMING_DOTS = '...';
@@ -77,8 +77,8 @@ export const highlight = (
     return chalk.dim(filePath);
   }
 
-  const strippedRawPath = stripAnsi(rawPath);
-  const strippedFilePath = stripAnsi(filePath);
+  const strippedRawPath = stripVTControlCharacters(rawPath);
+  const strippedFilePath = stripVTControlCharacters(filePath);
   const match = strippedRawPath.match(regexp);
 
   if (!match || match.index == null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5796,7 +5796,6 @@ __metadata:
     semver: "npm:^7.3.5"
     slash: "npm:^5.0.0"
     string-length: "npm:^6.0.0"
-    strip-ansi: "npm:^7.0.1"
     typescript: "npm:^5.0.4"
     typescript-eslint: "npm:^8.0.0"
   peerDependencies:


### PR DESCRIPTION
This PR replaces `strip-ansi` dependency with native node.js `stripVTControlCharacters` from `node:util`. 
All tests pass. It internally uses the same logic as `strip-ansi` (https://github.com/stylelint/stylelint/issues/8016), so it should be safe to remove.

ref: https://github.com/e18e/ecosystem-issues/issues/122